### PR TITLE
Remove duplicate toolchain requirement

### DIFF
--- a/private/def.bzl
+++ b/private/def.bzl
@@ -75,7 +75,6 @@ license_test = go_rule(
             default = Label("@rules_go//:go_context_data"),
         ),
     },
-    toolchains = [Label("@rules_go//go:toolchain")],
     implementation = _license_test_impl,
 )
 


### PR DESCRIPTION
This is handled by the go_rule macro.